### PR TITLE
Added support for passReqToCallback option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ build/Release
 # Deployed apps should consider commenting this line out:
 # see https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules
+
+# IDE metadata directory
+.idea/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ passport-client-cert is for TLS connections direct to a Node.js application.
 ## Usage
 The strategy constructor requires a verify callback, which will be executed on each authenticated request. It is responsible for checking the validity of the certificate and user authorisation.
 
+### Options
+
+* `passReqToCallback` - optional. Causes the request object to be supplied to the verify callback as the first parameter.
+
 The verify callback is passed with the [client certificate object](https://nodejs.org/api/tls.html#tls_tlssocket_getpeercertificate_detailed) and a `done` callback. The `done` callback must be called as per the [passport.js documentation](http://passportjs.org/guide/configure/).
 
 ````javascript
@@ -16,6 +20,22 @@ var passport = require('passport');
 var ClientCertStrategy = require('passport-client-cert').Strategy;
 
 passport.use(new ClientCertStrategy(function(clientCert, done) {
+  var cn = clientCert.subject.cn,
+      user = null;
+      
+  // The CN will typically be checked against a database
+  if(cn === 'test-cn') {
+    user = { name: 'Test User' }
+  }
+  
+  done(null, user);
+}));
+````
+
+The verify callback can be supplied with the `request` object by setting the `passReqToCallback` option to `true`, and changing callback arguments accordingly.
+
+````javascript
+passport.use(new ClientCertStrategy({ passReqToCallback: true }, function(req, clientCert, done) {
   var cn = clientCert.subject.cn,
       user = null;
       

--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
   },
   "homepage": "https://github.com/ripjar/passport-client-cert",
   "dependencies": {
-    "passport-strategy": "1.*"
+    "passport-strategy": "^1.0.0"
   },
   "devDependencies": {
-    "passport": "^0.2.0",
-    "chai": "^1.9.1",
-    "colors": "^0.6.2",
-    "express": "3.*",
-    "mocha": "^1.20.1"
+    "chai": "^3.3.0",
+    "colors": "^1.1.2",
+    "express": "^4.13.3",
+    "mocha": "^2.3.3",
+    "passport": "^0.3.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ function ClientCertStrategy(options, verify) {
   Strategy.call(this);
   this.name = 'client-cert';
   this._verify = verify;
+  this._passReqToCallback = options.passReqToCallback;
 }
 
 util.inherits(ClientCertStrategy, Strategy);
@@ -33,11 +34,17 @@ ClientCertStrategy.prototype.authenticate = function(req, options) {
       that.fail();
     } else {
 
-      this._verify(clientCert, function(err, user) {
+      var verified = function verified(err, user) {
         if (err) { return that.error(err); }
         if (!user) { return that.fail(); }
         that.success(user);
-      });
+      };
+
+      if (this._passReqToCallback) {
+        this._verify(req, clientCert, verified);
+      } else {
+        this._verify(clientCert, verified);
+      }
     }
   }
 };

--- a/test/client-strategy-test.js
+++ b/test/client-strategy-test.js
@@ -122,6 +122,25 @@ describe('Client cert strategy', function() {
       ok.should.eq(true);
     });
 
+    it("should pass the request object to the verify callback when directed", function () {
+      var passedReq;
+
+      strategy = new Strategy({ passReqToCallback: true }, function (req, cert, done) {
+        passedReq = req;
+        done(null, {});
+      });
+
+      strategy.fail = fail;
+      strategy.success = success;
+      req = helpers.dummyReq(true, cert);
+
+      strategy.authenticate(req);
+
+      failed.should.eq(false);
+      succeeded.should.eq(true);
+      passedReq.should.eq(req);
+    });
+
   });
 
 });


### PR DESCRIPTION
I added support for the `passReqToCallback` option that is fairly prevalent in passport strategies. As in most of the other implementations, I broke out your `verified` function into its own definition. Most of them just use a function statement, but to follow your lint/hint settings, I used an assigned (but named) function expression instead.

I couldn't get your devdeps to install properly (probably issues with the old versions), so I updated those dependencies. The tests still ran, so hopefully all is well there. I added a test to verify that this works.
