### PR TITLE
Fail if certificate missing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ ClientCertStrategy.prototype.authenticate = function(req, options) {
 
   // Requests must be authorized
   // (i.e. the certificate must be signed by at least one trusted CA)
-  if(!req.client.authorized) {
+  if(!req.client || !req.client.authorized) {
     that.fail();
   } else {
     var clientCert = req.connection.getPeerCertificate();


### PR DESCRIPTION
Fixes:

```
» curl localhost:3000/health
Cannot read property 'authorized' of undefined% 
```

On the server

```
 TypeError: Cannot read property 'authorized' of undefined
    at ClientCertStrategy.authenticate (/Projects/node_modules/passport-client-cert/src/index.js:27:17)
    at attempt (/Projects/node_modules/passport/lib/middleware/authenticate.js:348:16)
```
