### PR TITLE
VerifyFunctionWithRequest has invalid typings definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -32,7 +32,7 @@ export interface VerifyCallback {
 }
 
 export interface VerifyFunctionWithRequest {
-  (clientCert: PeerCertificate, req: Request, done: VerifyCallback): void;
+  (req: Request, clientCert: PeerCertificate, done: VerifyCallback): void;
 }
 
 export interface VerifyFunction {


### PR DESCRIPTION
VerifyFunctionWithRequest expects req, clientCert, done but the typescript definition was clientCert, req, done.